### PR TITLE
Fix location of config file in mentioned in manual

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -1940,7 +1940,7 @@ you to group related hosts by institution, owner, hardware, etc.
 \begin{enumerate}
 \item \file[config]{./config}
 \item \file[config-local]{\$PENCIL_HOME/config-local}
-\item \file[config-local]{\$HOME/.pencil/config-local}
+\item \file[config]{\$HOME/.pencil/config}
 \item \file[config]{\$PENCIL_HOME/config}
 \end{enumerate}
 This allows you to override part of the \file{config/} tree globally on


### PR DESCRIPTION
The manual mentions the wrong location for the config file (`\$HOME/.pencil/config-local`). However, line 36 of `lib/perl/pencil/ConfigFinder.pm`, searches for `$ENV{HOME}/.pencil/config`, and not the mentioned location.